### PR TITLE
Add universal project structure and setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+ENV=production
+DATABASE_URL=postgresql://user:password@localhost:5432/db
+FRAPPE_API_KEY=
+GOOGLE_DRIVE_FOLDER_ID=

--- a/README_codex.md
+++ b/README_codex.md
@@ -1,0 +1,14 @@
+# Установка и тестирование Codex
+
+Codex должен запускать `setup.sh` для установки Frappe и приложения `ferum_customs`.
+
+## Зависимости
+- Python >= 3.10
+- Frappe (устанавливается через bench)
+- Pre-commit
+- Pytest
+
+## Задачи
+- Прогон тестов: `pytest`
+- Проверка кода: `pre-commit`
+

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,8 @@
+from fastapi import FastAPI
+
+app = FastAPI()
+
+
+@app.get("/")
+def read_root():
+    return {"status": "ok"}

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,2 @@
+fastapi
+uvicorn

--- a/codex.yaml
+++ b/codex.yaml
@@ -1,0 +1,13 @@
+image: universal
+
+setup:
+  run: |
+    bash ./scripts/setup.sh
+
+test:
+  - name: Python tests
+    run: pytest tests/
+
+lint:
+  - name: black
+    run: black . --check

--- a/docs/doctype_config.yaml
+++ b/docs/doctype_config.yaml
@@ -1,0 +1,66 @@
+doctype:
+  - name: Service Report
+    fields:
+      - fieldname: service_request
+        fieldtype: Link
+        options: Service Request
+      - fieldname: report_date
+        fieldtype: Date
+      - fieldname: assigned_engineers
+        fieldtype: Table
+        options: Assigned Engineer Item
+    events:
+      validate: ferum_customs.custom_logic.service_report_hooks.validate
+      on_submit: ferum_customs.custom_logic.service_report_hooks.on_submit
+      after_insert: ferum_customs.custom_logic.service_report_hooks.after_insert
+      on_cancel: ferum_customs.custom_logic.service_report_hooks.on_cancel
+
+  - name: Service Request
+    events:
+      validate: ferum_customs.custom_logic.service_request_hooks.validate
+      on_update_after_submit: ferum_customs.custom_logic.service_request_hooks.on_update_after_submit
+      on_trash: ferum_customs.custom_logic.service_request_hooks.prevent_deletion_with_links
+      after_insert: ferum_customs.custom_logic.service_request_hooks.after_insert
+      on_cancel: ferum_customs.custom_logic.service_request_hooks.on_cancel
+
+  - name: Service Object
+    events:
+      validate: ferum_customs.custom_logic.service_object_hooks.validate
+
+  - name: Payroll Entry Custom
+    events:
+      validate: ferum_customs.custom_logic.payroll_entry_hooks.validate
+      before_save: ferum_customs.custom_logic.payroll_entry_hooks.before_save
+
+  - name: Custom Attachment
+    events:
+      on_trash: ferum_customs.custom_logic.file_attachment_utils.on_custom_attachment_trash
+
+  - name: Service Contract
+    fields:
+      - fieldname: customer
+        fieldtype: Link
+        options: Customer
+      - fieldname: sla
+        fieldtype: Int
+    events: {}
+
+  - name: Invoice
+    fields:
+      - fieldname: service_report
+        fieldtype: Link
+        options: Service Report
+    events: {}
+
+  - name: Site
+    fields:
+      - fieldname: address
+        fieldtype: Data
+    events: {}
+
+  - name: Maintenance Plan
+    fields:
+      - fieldname: site
+        fieldtype: Link
+        options: Site
+    events: {}

--- a/docs/project_summary.md
+++ b/docs/project_summary.md
@@ -1,0 +1,64 @@
+# Сводка по текущей реализации
+
+## Набор DocType
+
+На данный момент в приложении `ferum_customs` определены следующие DocType:
+
+- `Service Request`
+- `Service Report`
+- `Service Report Work Item`
+- `Service Report Document Item`
+- `Service Object`
+- `Service Project`
+- `Assigned Engineer Item`
+- `Payroll Entry Custom`
+- `Custom Attachment`
+- `Audit Log`
+- `Service Contract`
+- `Invoice`
+- `Site`
+- `Maintenance Plan`
+
+## Хуки (custom_hooks)
+
+Файл `ferum_customs/custom_hooks.py` задаёт обработчики событий DocType:
+
+- **Service Request** – `validate`, `on_update_after_submit`, `on_trash`, `after_insert`, `on_cancel`
+- **Service Report** – `validate`, `on_submit`, `after_insert`, `on_cancel`
+- **Service Object** – `validate`
+- **Payroll Entry Custom** – `validate`, `before_save`
+- **Custom Attachment** – `on_trash`
+
+## API
+
+В `ferum_customs/api.py` реализованы whitelisted‑методы:
+
+- `validate_service_request`
+- `on_submit_service_request`
+- `cancel_service_request`
+- `validate_service_report`
+- `on_submit_service_report`
+- `create_invoice_from_report`
+- `get_request_status`
+- `get_report_status`
+- `generate_pdf`
+- `create_pdf_attachment`
+
+Они доступны через `frappe.call` и могут использоваться для интеграций.
+
+## Автоматизация и вспомогательные сценарии
+
+- Скрипты `scripts/backup.sh` и `scripts/restore.sh` создают и восстанавливают резервные копии.
+- В каталоге `scripts/systemd` присутствуют юнит‑файлы `ferum_backup.service` и `ferum_backup.timer` для ежедневного запуска резервного копирования.
+- В каталоге `scripts/cron` есть пример cron‑задания `ferum_backup`.
+- Модуль `ferum_customs/custom_logic/automation.py` содержит функции автоматического назначения инженеров по зоне, напоминаний о сроках и проверки SLA.
+
+
+## Тесты
+
+Подробные тесты расположены в `ferum_customs/tests/` и покрывают логику хуков, API и утилит.
+Дополнительные сценарии проверяют цепочку от `Service Request` до создания `Invoice`.
+
+## Конфигурационный файл
+
+Сводка DocType и соответствующих хуков приведена в `docs/doctype_config.yaml`.

--- a/ferum_customs/api.py
+++ b/ferum_customs/api.py
@@ -93,3 +93,39 @@ def create_invoice_from_report(service_report: str) -> str:
 
     invoice.insert(ignore_permissions=True)
     return invoice.name
+
+
+@whitelist()
+def get_request_status(docname: str) -> Optional[str]:
+    """Return status of the given Service Request."""
+    return frappe.db.get_value("Service Request", docname, "status")
+
+
+@whitelist()
+def get_report_status(docname: str) -> Optional[str]:
+    """Return status of the given Service Report."""
+    return frappe.db.get_value("Service Report", docname, "status")
+
+
+@whitelist()
+def generate_pdf(doctype: str, docname: str, print_format: str | None = None) -> bytes:
+    """Return PDF bytes for the specified document using a print format."""
+    return frappe.get_print(doctype, docname, print_format=print_format, as_pdf=True)
+
+
+@whitelist()
+def create_pdf_attachment(
+    doctype: str, docname: str, print_format: str | None = None
+) -> str:
+    """Generate PDF attachment from template and attach to the document."""
+    pdf = generate_pdf(doctype, docname, print_format)
+    file_doc = frappe.get_doc(
+        {
+            "doctype": "File",
+            "file_name": f"{doctype}-{docname}.pdf",
+            "content": pdf,
+            "attached_to_doctype": doctype,
+            "attached_to_name": docname,
+        }
+    ).insert(ignore_permissions=True)
+    return file_doc.file_url

--- a/ferum_customs/custom_hooks.py
+++ b/ferum_customs/custom_hooks.py
@@ -5,10 +5,14 @@ DOC_EVENTS = {
         "validate": "ferum_customs.custom_logic.service_request_hooks.validate",
         "on_update_after_submit": "ferum_customs.custom_logic.service_request_hooks.on_update_after_submit",
         "on_trash": "ferum_customs.custom_logic.service_request_hooks.prevent_deletion_with_links",
+        "after_insert": "ferum_customs.custom_logic.service_request_hooks.after_insert",
+        "on_cancel": "ferum_customs.custom_logic.service_request_hooks.on_cancel",
     },
     "Service Report": {
         "validate": "ferum_customs.custom_logic.service_report_hooks.validate",
         "on_submit": "ferum_customs.custom_logic.service_report_hooks.on_submit",
+        "after_insert": "ferum_customs.custom_logic.service_report_hooks.after_insert",
+        "on_cancel": "ferum_customs.custom_logic.service_report_hooks.on_cancel",
     },
     "Service Object": {
         "validate": "ferum_customs.custom_logic.service_object_hooks.validate",

--- a/ferum_customs/custom_logic/automation.py
+++ b/ferum_customs/custom_logic/automation.py
@@ -1,0 +1,45 @@
+"""Automation helpers for engineer assignment and SLA checks."""
+
+from __future__ import annotations
+
+import frappe
+
+
+def assign_engineers_by_zone(doc, method: str | None = None) -> None:
+    """Assign engineers based on the service object's zone."""
+    zone = doc.get("zone")
+    if not zone:
+        return
+
+    engineers = frappe.get_all(
+        "Employee",
+        filters={"zone": zone},
+        pluck="user_id",
+    )
+
+    for engineer in engineers:
+        doc.append("assigned_engineers", {"engineer": engineer})
+
+
+def remind_due_dates() -> None:
+    """Send reminders about approaching due dates for open requests."""
+    open_requests = frappe.get_all(
+        "Service Request",
+        filters={"status": ["not in", ["Closed", "Cancelled"]]},
+        fields=["name", "expected_end_date", "custom_assigned_engineer"],
+    )
+
+    for req in open_requests:
+        if req.expected_end_date and req.expected_end_date <= frappe.utils.today():
+            frappe.sendmail(
+                recipients=[req.custom_assigned_engineer],
+                subject=f"Reminder for {req.name}",
+                message="Service Request is due",
+            )
+
+
+def check_sla(doc, method: str | None = None) -> None:
+    """Warn if the response time exceeds the contract SLA."""
+    sla = frappe.db.get_value("Service Contract", doc.get("service_contract"), "sla")
+    if sla and doc.get("response_time") and doc.response_time > sla:
+        frappe.msgprint("SLA breach detected", alert=True)

--- a/ferum_customs/custom_logic/service_report_hooks.py
+++ b/ferum_customs/custom_logic/service_report_hooks.py
@@ -129,3 +129,13 @@ def on_submit(doc: "ServiceReport", method: str | None = None) -> None:
                 "Произошла ошибка при обновлении связанной заявки. Обратитесь к администратору."
             )
         )
+
+
+def after_insert(doc: "ServiceReport", method: str | None = None) -> None:
+    """Log creation of a Service Report."""
+    frappe.logger(__name__).info(f"Service Report '{doc.name}' created")
+
+
+def on_cancel(doc: "ServiceReport", method: str | None = None) -> None:
+    """Log cancellation of a Service Report."""
+    frappe.logger(__name__).info(f"Service Report '{doc.name}' cancelled")

--- a/ferum_customs/custom_logic/service_request_hooks.py
+++ b/ferum_customs/custom_logic/service_request_hooks.py
@@ -82,6 +82,16 @@ def prevent_deletion_with_links(
         )
 
 
+def after_insert(doc: "ServiceRequest", method: str | None = None) -> None:
+    """Log creation of a Service Request."""
+    frappe.logger(__name__).info(f"Service Request '{doc.name}' created")
+
+
+def on_cancel(doc: "ServiceRequest", method: str | None = None) -> None:
+    """Log cancellation of a Service Request."""
+    frappe.logger(__name__).info(f"Service Request '{doc.name}' cancelled")
+
+
 # --------------------------------------------------------------------------- #
 #                           Whitelisted Methods                             #
 # --------------------------------------------------------------------------- #

--- a/ferum_customs/tests/test_new_hooks.py
+++ b/ferum_customs/tests/test_new_hooks.py
@@ -1,0 +1,36 @@
+import os
+
+import pytest
+
+pytest.importorskip("frappe")
+
+import frappe  # noqa: E402
+from frappe.tests.utils import FrappeTestCase  # noqa: E402
+
+from ferum_customs.custom_logic import service_report_hooks, service_request_hooks
+
+
+class DummyLogger:
+    def __init__(self):
+        self.messages = []
+
+    def info(self, msg):
+        self.messages.append(msg)
+
+
+class TestNewHooks(FrappeTestCase):
+    TEST_SITE = os.environ.get("SITE_NAME", getattr(frappe.local, "site", None))
+
+    def test_after_insert_request(self, monkeypatch, frappe_site):
+        logger = DummyLogger()
+        monkeypatch.setattr(frappe, "logger", lambda *a, **k: logger)
+        doc = frappe._dict(name="REQ-1")
+        service_request_hooks.after_insert(doc)
+        self.assertIn("REQ-1", logger.messages[0])
+
+    def test_after_insert_report(self, monkeypatch, frappe_site):
+        logger = DummyLogger()
+        monkeypatch.setattr(frappe, "logger", lambda *a, **k: logger)
+        doc = frappe._dict(name="REP-1")
+        service_report_hooks.after_insert(doc)
+        self.assertIn("REP-1", logger.messages[0])

--- a/ferum_customs/tests/test_status_api.py
+++ b/ferum_customs/tests/test_status_api.py
@@ -1,0 +1,40 @@
+import os
+
+import pytest
+
+pytest.importorskip("frappe")
+
+import frappe  # noqa: E402
+from frappe.tests.utils import FrappeTestCase  # noqa: E402
+
+from ferum_customs import api  # noqa: E402
+
+
+class TestStatusAPI(FrappeTestCase):
+    TEST_SITE = os.environ.get("SITE_NAME", getattr(frappe.local, "site", None))
+
+    def test_get_request_status(self, monkeypatch, frappe_site):
+        monkeypatch.setattr(frappe.db, "get_value", lambda *a, **k: "Open")
+        status = api.get_request_status("REQ-1")
+        self.assertEqual(status, "Open")
+
+    def test_get_report_status(self, monkeypatch, frappe_site):
+        monkeypatch.setattr(frappe.db, "get_value", lambda *a, **k: "Draft")
+        status = api.get_report_status("REP-1")
+        self.assertEqual(status, "Draft")
+
+    def test_get_request_status_missing(self, monkeypatch, frappe_site):
+        def raise_missing(*a, **k):
+            raise frappe.DoesNotExistError
+
+        monkeypatch.setattr(frappe.db, "get_value", raise_missing)
+        with pytest.raises(frappe.DoesNotExistError):
+            api.get_request_status("REQ-missing")
+
+    def test_get_report_status_missing(self, monkeypatch, frappe_site):
+        def raise_missing(*a, **k):
+            raise frappe.DoesNotExistError
+
+        monkeypatch.setattr(frappe.db, "get_value", raise_missing)
+        with pytest.raises(frappe.DoesNotExistError):
+            api.get_report_status("REP-missing")

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "ferum-customs-frontend",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "test": "echo \"no tests specified\" && exit 0"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  }
+}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export default function App() {
+  return <h1>Ferum Customs</h1>;
+}

--- a/frontend/src/index.jsx
+++ b/frontend/src/index.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import App from './App';
+
+document.addEventListener('DOMContentLoaded', () => {
+  const rootElement = document.getElementById('root');
+  if (rootElement) {
+    createRoot(rootElement).render(<App />);
+  }
+});

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -e
+
+# Установка Python-зависимостей
+cd backend
+pip install -r requirements.txt || exit 1
+cd ..
+
+# Установка Node-зависимостей
+cd frontend
+npm install || exit 1
+cd ..
+
+echo "Setup completed successfully."

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -e
+
+# setup.sh - prepare a Frappe bench with the ferum_customs app
+
+echo "\U1F4E6 Installing dependencies..."
+pip install -U pip setuptools wheel
+pip install frappe-bench
+
+echo "\U1F527 Initializing bench..."
+bench init ferum-bench --frappe-branch version-15
+cd ferum-bench
+
+# add the ferum_customs app from this repository
+APP_PATH="$(cd .. && pwd)"
+bench get-app ferum_customs "$APP_PATH"
+bench new-site test.local
+bench --site test.local install-app ferum_customs
+

--- a/tests/test_sample.py
+++ b/tests/test_sample.py
@@ -1,0 +1,2 @@
+def test_true():
+    assert True


### PR DESCRIPTION
## Summary
- add backend with basic FastAPI app
- add frontend scaffold
- add setup script for installing Python and Node deps
- configure codex tasks for setup, test and lint with black
- include example environment variables and minimal unit test
- add React component scaffold and tests for API error paths

## Testing
- `pip install -r dev-requirements.txt` *(fails: CONNECT tunnel failed)*
- `pre-commit run --all-files` *(fails: command not found)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'frappe')*


------
https://chatgpt.com/codex/tasks/task_e_686298434f4083289a90b97eb127ad1f